### PR TITLE
Fix error on first-time apply

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.0.1] - 2023-06-24
+
+### Fixed
+
+- No longer returns an error the first time the TLS certificate is created
+- Broken link in changelog
+
 ## [1.0.0] - 2023-06-14
 
 ### Added
@@ -14,4 +21,5 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - CloudWatch logging infrastructure for incoming traffic
 - Support for setting a custom domain name and path prefix for the API Gateway
 
-[1.0.0]: https://github.com/olivierlacan/keep-a-changelog/releases/tag/v0.0.1
+[1.0.1]: https://github.com/olivierlacan/keep-a-changelog/compare/v1.0.0...v1.0.1
+[1.0.0]: https://github.com/olivierlacan/keep-a-changelog/releases/tag/v1.0.0

--- a/README.md
+++ b/README.md
@@ -20,12 +20,5 @@ module {
 }
 ```
 
-Note: due to a [bug](https://github.com/hashicorp/terraform-provider-aws/issues/32025)
-in the AWS provider, the first attempt to create the proxy will most
-likely fail. It happens because the TLS certificate is
-eventually-consistent and the provider tries to create dependent
-resources before the certificate is ready. Re-applying after the initial
-failure should fix the problem.
-
 The module will create a proxy gateway at the requested location, with a
 valid TLS certificate. Logs are streamed to CloudWatch.

--- a/dns.tf
+++ b/dns.tf
@@ -14,7 +14,7 @@ resource "aws_apigatewayv2_domain_name" "proxy" {
   domain_name = aws_acm_certificate.proxy.domain_name
 
   domain_name_configuration {
-    certificate_arn = aws_acm_certificate.proxy.arn
+    certificate_arn = aws_acm_certificate_validation.proxy.certificate_arn
     endpoint_type   = "REGIONAL"
     security_policy = "TLS_1_2"
   }


### PR DESCRIPTION
# Change Summary
This commit applies the Hashicorp-recommended
[workaround](https://github.com/hashicorp/terraform-provider-aws/issues/32025#issuecomment-1599344398) for the bug where Terraform tries to use ACM certificates before they are available. We are already using a resource,
`aws_acm_certificate_validation`, that depends on the certificate and is smart enough to wait for the certificate to be available. That resource also exposes the certificate ARN, so we can is re-order the dependency graph to use rely on it instead.

Previous:
Cert -> Verification (works correctly)
Cert -> Domain Name Config (broken)

New:
Cert -> Verification -> Domain Name Config

# To Test

- Ensure you have a valid AWS credentials file
- `cd examples/proxy-to-example-dot-com`
- Place a `my.tfvars` file there that specifies a new subdomain in a hosted zone zone you control (I will share one with @spdolan privately)
- `terraform apply -var-file=my.tfvars`
  - On version 1.0.0 you will get an error the first time (but subsequent attempts will succeed).
  - In this branch it works correctly the first time.
- Make sure to run `terraform destroy -var-file=my.tfvars` after each test.