### PR TITLE
Add option to support custom routes and integrations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+examples/*/.terraform*
+examples/*/terraform.tfstate

--- a/README.md
+++ b/README.md
@@ -29,3 +29,10 @@ failure should fix the problem.
 
 The module will create a proxy gateway at the requested location, with a
 valid TLS certificate. Logs are streamed to CloudWatch.
+
+## Custom Integration
+
+To integrate with something other than an HTTP service, pass the variable
+`auto_create_route=false` and omit `target_url`. Then you can define your
+own `aws_apigatewayv2_route` and `aws_apigatewayv2_integration` objects.
+To attach them to the API Gateway, use the module's `api_id` output. 

--- a/examples/proxy_to_alb/main.tf
+++ b/examples/proxy_to_alb/main.tf
@@ -1,0 +1,24 @@
+module "proxy" {
+  source = "../.."
+  api_display_name = "example-alb-proxy"
+  api_description = "Transparent proxy to a simple AWS Application Load Balancer"
+  api_mapping_key = ""
+  full_domain_name = var.domain_name
+  hosted_zone_id = var.route53_hosted_zone_id
+  auto_create_route = false
+}
+
+resource "aws_apigatewayv2_route" "custom_route" {
+  api_id    = module.proxy.api_id
+  route_key = "$default"
+  target    = format("integrations/%s", aws_apigatewayv2_integration.custom_integration.id)
+}
+
+resource "aws_apigatewayv2_integration" "custom_integration" {
+  api_id             = module.proxy.api_id
+  integration_type   = "HTTP_PROXY"
+  integration_method = "ANY"
+  integration_uri    = aws_lb_listener.hello.arn
+  connection_type = "VPC_LINK"
+  connection_id = aws_apigatewayv2_vpc_link.target.id
+}

--- a/examples/proxy_to_alb/target.tf
+++ b/examples/proxy_to_alb/target.tf
@@ -1,0 +1,36 @@
+resource "aws_lb" "target" {
+  name = "test-lb"
+  internal = true
+  load_balancer_type = "application"
+  subnets = [ for s in aws_subnet.subnet : s.id ]
+  security_groups = [ aws_security_group.target.id ]
+}
+
+resource "aws_lb_listener" "hello" {
+  load_balancer_arn = aws_lb.target.arn
+  port = "80"
+  protocol = "HTTP"
+
+  default_action {
+    type = "fixed-response"
+
+    fixed_response {
+      content_type = "text/plain"
+      message_body = "Hello, World!"
+      status_code = "200"
+    }
+  }
+}
+
+resource "aws_security_group" "target" {
+  name = "test-load-balancer"
+  vpc_id = aws_default_vpc.vpc.id
+}
+
+resource "aws_vpc_security_group_ingress_rule" "ingress_to_target" {
+  security_group_id = aws_security_group.target.id
+  ip_protocol = "tcp"
+  cidr_ipv4 = "0.0.0.0/0"
+  from_port = 80
+  to_port = 80
+}

--- a/examples/proxy_to_alb/variables.tf
+++ b/examples/proxy_to_alb/variables.tf
@@ -1,0 +1,9 @@
+variable domain_name {
+  type = string
+  description = "Domain name where the proxy should be hosted"
+}
+
+variable route53_hosted_zone_id {
+  type = string
+  description = "Your Route53 zone"
+}

--- a/examples/proxy_to_alb/vpc.tf
+++ b/examples/proxy_to_alb/vpc.tf
@@ -1,0 +1,51 @@
+resource "aws_default_vpc" "vpc" {}
+
+data "aws_availability_zones" "available" {
+  state = "available"
+}
+
+resource "aws_route_table" "private" {
+  vpc_id = aws_default_vpc.vpc.id
+  route = []
+}
+
+resource "aws_subnet" "subnet" {
+  for_each = { for i, name in data.aws_availability_zones.available.names: i => name }
+  vpc_id = aws_default_vpc.vpc.id
+  availability_zone = each.value
+  cidr_block = cidrsubnet(aws_default_vpc.vpc.cidr_block, 4, 8 + each.key)
+  map_public_ip_on_launch = false
+}
+
+resource "aws_route_table_association" "private" {
+  for_each = aws_subnet.subnet
+  subnet_id = each.value.id
+  route_table_id = aws_route_table.private.id
+}
+
+resource "aws_apigatewayv2_vpc_link" "target" {
+  name = "test-vpc-link"
+  security_group_ids = [ aws_security_group.vpc_link.id ]
+  subnet_ids = [ for s in aws_subnet.subnet : s.id ]
+}
+
+resource "aws_security_group" "vpc_link" {
+  name = "test-vpc-link"
+  vpc_id = aws_default_vpc.vpc.id
+}
+
+resource "aws_vpc_security_group_egress_rule" "vpc_link_to_load_balancer" {
+  security_group_id = aws_security_group.vpc_link.id
+  ip_protocol = "tcp"
+  from_port = 80
+  to_port = 80
+  referenced_security_group_id = aws_security_group.target.id
+}
+
+resource "aws_vpc_security_group_ingress_rule" "vpc_link_from_internet" {
+  security_group_id = aws_security_group.vpc_link.id
+  ip_protocol = "tcp"
+  from_port = 80
+  to_port = 80
+  cidr_ipv4 = "0.0.0.0/0"
+}

--- a/main.tf
+++ b/main.tf
@@ -64,12 +64,14 @@ resource "aws_apigatewayv2_deployment" "proxy" {
 }
 
 resource "aws_apigatewayv2_route" "proxy" {
+  count = var.auto_create_route ? 1 : 0
   api_id    = aws_apigatewayv2_api.proxy.id
   route_key = "$default"
-  target    = format("integrations/%s", aws_apigatewayv2_integration.proxy.id)
+  target    = format("integrations/%s", var.auto_create_route ? aws_apigatewayv2_integration.proxy[0].id : "")
 }
 
 resource "aws_apigatewayv2_integration" "proxy" {
+  count = var.auto_create_route ? 1 : 0
   api_id             = aws_apigatewayv2_api.proxy.id
   integration_type   = "HTTP_PROXY"
   integration_method = "ANY"

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,0 +1,3 @@
+output "api_id" {
+  value = aws_apigatewayv2_api.proxy.id
+}

--- a/variables.tf
+++ b/variables.tf
@@ -23,7 +23,14 @@ variable "hosted_zone_id" {
   description = "ID of the Route53 Hosted Zone that routes to the API Gateway"
 }
 
+variable "auto_create_route" {
+  type = bool
+  description = "Automatically create the proxy route and integration"
+  default = true
+}
+
 variable "target_url" {
   type = string
-  description = "URL of the site to proxy"
+  description = "URL of the site to proxy. Required if auto_create_route = true; ignored otherwise"
+  default = ""
 }


### PR DESCRIPTION
I had to move PaperTrace from an HTTP integration to an ALB integration. This change allows us to adapt our usage of the `http-proxy` module rather than changing dependencies or copying a bunch of code. Example usage is included.